### PR TITLE
Show bugref or 'review pending' for failed jobs

### DIFF
--- a/suse_msg/meta/openqa.py
+++ b/suse_msg/meta/openqa.py
@@ -19,6 +19,8 @@ class OpenQAProcessor(BaseProcessor):
             if self.event == 'done':
                 s += " with result "
                 s += self.colored_job_result(c)
+                if self.msg.get('result') == 'failed':
+                    s += " (%s)" % self.msg.get('bugref', 'review pending')
             s += ": " + self.job_url()
         elif self.object == 'comment':
             if self.is_group_event():


### PR DESCRIPTION
* In accordance with https://github.com/os-autoinst/openQA/commit/e3d3b065bba7f1acd535085de25ddbba71fa69d1
* See https://progress.opensuse.org/issues/16276

---

Tested locally. It looks like this:  
```
[15:04] [Notice] -hermes2 an #openqa-events2- openQA job finished with result failed (review pending): https://openqa.opensuse.org/t123
[15:05] [Notice] -hermes2 an #openqa-events2- openQA job finished with result failed (bsc#123): https://openqa.opensuse.org/t123
```

---

This should be deployed after the change on the openQA-side is deployed.